### PR TITLE
Update ZenkeRule defaults to the Zenke et al. 2015 values

### DIFF
--- a/spark/nn/components/plasticity/zenke_rule.py
+++ b/spark/nn/components/plasticity/zenke_rule.py
@@ -50,7 +50,7 @@ class ZenkeRuleConfig(PlasticityConfig):
             'description': 'Time constant of the fast postynaptic spike train',
         })
     post_slow_tau: float | jax.Array | Initializer = dc.field(
-        default = 20.0, 
+        default = 100.0, 
         metadata = {
             'units': 'ms',
             'validators': [
@@ -60,7 +60,7 @@ class ZenkeRuleConfig(PlasticityConfig):
             'description': 'Time constant of the slow postynaptic spike train',
         })
     target_tau: float | jax.Array | Initializer = dc.field(
-        default = 20000.0, 
+        default = 1200000.0, 
         metadata = {
             'units': 'ms',
             'validators': [
@@ -70,7 +70,7 @@ class ZenkeRuleConfig(PlasticityConfig):
             'description': 'Time constant of the kernel target',
         })
     a: float | jax.Array = dc.field(
-        default = 1.0, 
+        default = 2.0, 
         metadata = {
             'validators': [
                 TypeValidator,
@@ -78,7 +78,7 @@ class ZenkeRuleConfig(PlasticityConfig):
             'description': 'Scale factor of the triplet LTP term.',
         })
     b: float | jax.Array = dc.field(
-        default = -1.0, 
+        default = -0.02, 
         metadata = {
             'validators': [
                 TypeValidator,
@@ -86,7 +86,7 @@ class ZenkeRuleConfig(PlasticityConfig):
             'description': 'Scale factor of the doublet LTD term.',
         })
     c: float | jax.Array = dc.field(
-        default = -1.0, 
+        default = -400.0, 
         metadata = {
             'validators': [
                 TypeValidator,
@@ -94,7 +94,7 @@ class ZenkeRuleConfig(PlasticityConfig):
             'description': 'Scale factor of the heterosynaptic plasticity term.',
         })
     d: float | jax.Array = dc.field(
-        default = 1.0, 
+        default = 2e-5, 
         metadata = {
             'validators': [
                 TypeValidator,
@@ -107,7 +107,7 @@ class ZenkeRuleConfig(PlasticityConfig):
             'validators': [
                 TypeValidator,
             ], 
-            'description': '',
+            'description': 'Scale factor of the double-well consolidation potential.',
         })
     eta: float | jax.Array = dc.field(
         default = 0.1, 


### PR DESCRIPTION
Follows up on discussion #21, where you noted the default configuration was never updated from the paper.

The short version: the published values cannot be transcribed directly. Doing so stops the divergence, but it does it by making the rule inert rather than by making it correct.

## Why

Every tracer in `ZenkeRule.build` is constructed with `scale=1/tau`, and `Tracer._update` adds `scale * x`, so a Spark trace increments by `1/τ` per spike. Zenke's traces follow `dz/dt = -z/τ + S(t)` and increment by 1. That gives `z_spark = z_zenke / τ`, so each coefficient has to absorb the time constants of the traces its own term multiplies:

| term | traces carried | correction |
|---|---|---|
| triplet LTP | `z_pre`, `z_slow` | `a = A · τ_pre · τ_slow` |
| doublet LTD | `z_post` | `b = −B · τ_post` |
| heterosynaptic | `z_post³` | `c = −β · τ_post³` |
| transmitter | none | `d = δ` |

The triplet term carries two traces, so a straight `a = A = 1e-3` runs 2000× under the paper's effective LTP rate. Measured over 20k steps at 30 Hz drive:

| defaults | ‖K‖ | 2nd-half drift | mean \|w − w₀\| |
|---|---|---|---|
| current | 5.2 → 1.08e4 | +90.2% | diverges |
| table transcribed directly | 5.1 → 5.08 | −0.4% | 9.8e-4 |
| this PR | 5.1 → 0.47 | −2.7% | 8.9e-2 |

The middle row looks stable because almost nothing happens: weights move by 0.5% of their initial scale and mean `w` ends at 0.097 against a 0.1 start. The corrected values move them 91× more and take mean `w` to 0.0095, which is the pruning the rule is supposed to do.

## Changes

Source values are Supplementary Table 2, section D3 of [10.1038/ncomms7922](https://doi.org/10.1038/ncomms7922): A = B = 1e-3, δ = 2e-5, β = 0.05, τ± = 20 ms, τ_slow = 100 ms, τ_cons = 20 min, P = 20.

| field | before | after |
|---|---|---|
| `post_slow_tau` | 20.0 | 100.0 |
| `target_tau` | 20000.0 | 1200000.0 |
| `a` | 1.0 | 2.0 |
| `b` | −1.0 | −0.02 |
| `c` | −1.0 | −400.0 |
| `d` | 1.0 | 2e-5 |

`pre_tau` and `post_tau` were already correct. So is `p`: it maps to the paper's P = 20, the potential strength parameter in the double-well consolidation term, not to the burst-detector exponent, which is the hardcoded `post_trace**3`. Its `description` was the only empty one in the config, so it is filled here.

`target_tau` was 20 s against τ_cons = 20 min in the paper, which looks like a units slip.

## Measured

Rule driven directly rather than inside a `Brain`, 64→32 kernel, Poisson drive, `dt = 1 ms`, float32. Stability is judged by whether ‖K‖ is still drifting in the second half of the run rather than by absolute size, since a rule that settles at a large norm is stable and one still climbing is not.

At 3 Hz the current defaults grow linearly with no saturation; corrected they settle at 3.6.

Ablating one change at a time at 30 Hz over 20k steps:

| variant | 2nd-half drift |
|---|---|
| current defaults | +90.2% |
| `post_slow_tau` only | +90.2% |
| `target_tau` only | +90.2% |
| **coefficients `a,b,c,d` only** | **−2.5%** |

So the four scale factors are the fix, and the two time-constant corrections are fidelity rather than stability.

Two controls, against the reading that smaller coefficients are simply more stable:

- `c = 0` (β = 0, heterosynaptic off) returns to runaway at +83.6% drift, matching the paper's own statement that weights reach the upper bound without heterosynaptic plasticity.
- Scaling the current coefficients down uniformly by 1e-3 does **not** reach equilibrium (+24.4% drift).

Caveat: this drives the rule with independent Poisson input, so it tests boundedness and the heterosynaptic mechanism only. It says nothing about bistability or assembly formation, which are network-level results in the paper.

Reproduction scripts live outside this repo. Happy to put them wherever is useful, or attach them to the discussion.

## Two things left for you

**`eta` is untouched at 0.1.** The paper has no global learning rate on the excitatory rule — the η = 2e-5 in that table is the inhibitory iSTDP one, listed under D4. All four terms carry exactly one spike-train factor, so if the 0/1 spike arrays stand in for delta functions then `eta = 1/dt` absorbs the convention uniformly. That is 1.0 at the default `dt` and numerically invisible, but not at any other timestep. It is a design call rather than a transcription error, so it seemed wrong to make it here. Every number above is with `eta` left at 0.1.

**`target_tau` interacts with dtype.** At `dt = 1 ms`, 20 min gives `exp(-dt/tau) = exp(-8.3e-7)`, which is 1.0 exactly in float16 — the consolidation trace would never decay. The measurements above are float32 for that reason. Worth knowing if float16 is a common path.

Separately and much smaller, not changed here: the weight update clips at `min=0.0` with no upper bound, where D3 constrains 0 ≤ w ≤ 5.

Opened against `main` and left as a draft. If `ZenkeRule` is being reworked in the update you mentioned, say so and I will retarget to `development` or close this.

On method: I used an LLM as an assistant here. The derivation and the runs are mine and every number is checkable against the supplementary table and the source, but you should know that when you decide how much to trust it.
